### PR TITLE
Add user allocation ad hoc task

### DIFF
--- a/classes/local/notification/start.php
+++ b/classes/local/notification/start.php
@@ -85,4 +85,16 @@ final class start extends base {
         }
         $rs->close();
     }
+
+    /**
+     * Send notification related to start.
+     *
+     * @param stdClass $user
+     * @param stdClass $program
+     * @param stdClass $source
+     * @param stdClass $allocation
+     */
+    public static function notify_now(stdClass $user, stdClass $program, stdClass $source, stdClass $allocation) {
+        self::notify_allocated_user($program, $source, $allocation, $user);
+    }
 }

--- a/classes/local/program.php
+++ b/classes/local/program.php
@@ -27,6 +27,25 @@ use stdClass;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class program {
+    /** @var array array of program records */
+    private static $programs = [];
+
+    /**
+     * Retrieve program instance by id.
+     *
+     * @param int $id the program id
+     * @return stdClass the program record
+     */
+    public static function get_instance(int $id): stdClass {
+        global $DB;
+
+        if (!isset(self::$programs[$id])) {
+            self::$programs[$id] = $DB->get_record('enrol_programs_programs', ['id' => $id], '*', MUST_EXIST);
+        }
+
+        return self::$programs[$id];
+    }
+
     /**
      * Options for editing of program descriptions.
      *

--- a/classes/local/source/cohort.php
+++ b/classes/local/source/cohort.php
@@ -204,7 +204,7 @@ final class cohort extends base {
      * @return bool true if anything updated
      */
     public static function fix_allocations(?int $programid, ?int $userid): bool {
-        global $DB;
+        global $DB, $USER;
 
         $updated = false;
 
@@ -236,26 +236,25 @@ final class cohort extends base {
                        $programselect $userselect
               ORDER BY p.id ASC, s.id ASC";
         $rs = $DB->get_recordset_sql($sql, $params);
-        $lastprogram = null;
-        $lastsource = null;
         foreach ($rs as $record) {
             if ($record->allocationid) {
                 $DB->set_field('enrol_programs_allocations', 'archived', 0, ['id' => $record->allocationid]);
-            } else {
-                if ($lastprogram && $lastprogram->id == $record->id) {
-                    $program = $lastprogram;
-                } else {
-                    $program = $DB->get_record('enrol_programs_programs', ['id' => $record->id], '*', MUST_EXIST);
-                    $lastprogram = $program;
-                }
-                if ($lastsource && $lastsource->id == $record->sourceid) {
-                    $source = $lastsource;
-                } else {
-                    $source = $DB->get_record('enrol_programs_sources', ['id' => $record->sourceid], '*', MUST_EXIST);
-                    $lastsource = $source;
-                }
-                self::allocate_user($program, $source, $record->userid, []);
                 $updated = true;
+            } else {
+                if (PHPUNIT_TEST) {
+                    self::task_allocate_user($record->id, $record->sourceid, $record->userid);
+                } else {
+                    $task = new \enrol_programs\task\allocate_user_task();
+                    $task->set_userid($USER->id);
+                    $task->set_custom_data([
+                        'programid'    => $record->id,
+                        'userid'       => $record->userid,
+                        'sourceid'     => $record->sourceid,
+                        'sourceclass'  => '\\' . self::class,
+                    ]);
+
+                    \core\task\manager::queue_adhoc_task($task, true);
+                }
             }
         }
         $rs->close();
@@ -299,5 +298,28 @@ final class cohort extends base {
         $rs->close();
 
         return $updated;
+    }
+
+    /**
+     * Allocate user to program.
+     *
+     * @param int $programid
+     * @param int $sourceid
+     * @param int $userid
+     * @return stdClass user allocation record
+     */
+    public static function task_allocate_user(int $programid, int $sourceid, int $userid): \stdClass {
+        global $DB;
+
+        $params = ['programid' => $programid, 'sourceid' => $sourceid, 'userid' => $userid];
+        if ($allocation = $DB->get_record('enrol_programs_allocations', $params)) {
+            // Allocation already exists, no need to allocate, just return the allocation.
+            return $allocation;
+        }
+
+        $program = \enrol_programs\local\program::get_instance($programid);
+        $source = self::get_instance($sourceid);
+
+        return self::allocate_user($program, $source, $userid, []);
     }
 }

--- a/classes/task/allocate_user_task.php
+++ b/classes/task/allocate_user_task.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace enrol_programs\task;
+
+/**
+ * Program user allocation task.
+ *
+ * @package    enrol_programs
+ * @author     Rossco Hellmans <rosscohellmans@catalyst-au.net>
+ * @copyright  2024 Catalyst IT Australia Pty Ltd
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class allocate_user_task extends \core\task\adhoc_task {
+    /**
+     * Get task name
+     */
+    public function get_name() {
+        return get_string('allocateusertask', 'enrol_programs');
+    }
+
+    /**
+     * Execute task
+     */
+    public function execute() {
+        $data = $this->get_custom_data();
+        $sourceclass = $data->sourceclass;
+
+        $sourceclass::task_allocate_user($data->programid, $data->sourceid, $data->userid, []);
+    }
+}
+
+

--- a/classes/task/cron.php
+++ b/classes/task/cron.php
@@ -45,8 +45,8 @@ class cron extends \core\task\scheduled_task {
 
         $trace = new \null_progress_trace();
 
-        \enrol_programs\local\allocation::fix_allocation_sources(null, null);
         \enrol_programs\local\allocation::fix_enrol_instances(null);
+        \enrol_programs\local\allocation::fix_allocation_sources(null, null);
         \enrol_programs\local\allocation::fix_user_enrolments(null, null);
         \enrol_programs\local\calendar::fix_program_events(null);
 

--- a/lang/en/enrol_programs.php
+++ b/lang/en/enrol_programs.php
@@ -27,6 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $string['addprogram'] = 'Add program';
 $string['addset'] = 'Add new set';
+$string['allocateusertask'] = 'Allocate user ad hoc task';
 $string['allocationend'] = 'Allocation end';
 $string['allocationend_help'] = 'Allocation end date meaning depends on enabled allocation sources. Usually new allocation are not possible after this date if specified.';
 $string['allocation'] = 'Allocation';


### PR DESCRIPTION
Also add fix_user_enrolments and start notification into allocation process

This allows parallel processing of user allocations when a big batch of cohort allocations happen.

With a testing scenario of 10,000 users in a cohort these were the timings;
Before change:
- Cron took 45 minutes

After change:
- Cron took 1 minute
- With 10 concurrent ad hoc runners the ad hoc tasks were all completed in 4.5 minutes